### PR TITLE
Story/parse bitmovin notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ jspm_packages
 .webpack
 .env
 
-event.json
-

--- a/event.json
+++ b/event.json
@@ -1,0 +1,3 @@
+{
+    "body": "{\"payload\":{\"outputUrl\":\"https://s3.amazonaws.com/execonline-staging-video/bitmovin/558134_27409232e193d8a2b0ff95d882486746\",\"jobId\":\"558134\"}}"
+}

--- a/src/handler.js
+++ b/src/handler.js
@@ -4,17 +4,25 @@ import BitmovinTransmuxingLambda from './BitmovinTransmuxingLambda';
 require('dotenv').config();
 const jf = require('jsonfile');
 
+function processMessage(event) {
+  const message = event.body
+  return message;
+}
+
 function entry(event, context, callback) {
   const bit = new BitmovinTransmuxingLambda();
   console.log('Starting new bitmovin transmuxing job');
-  bit.createTransmuxes();
+  const message = processMessage(event);
+  bit.createTransmuxes(message);
   callback(null, 'Success!');
 }
 
 function test() {
   const bit = new BitmovinTransmuxingLambda();
   console.log('Starting new bitmovin transmuxing job');
-  bit.createTransmuxes();
+  const event = jf.readFileSync('event.json');
+  const message = processMessage(event);
+  bit.createTransmuxes(message);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR:
1 makes the lambda read output url and job id from the incoming bitmovin notification, instead of finding the last finished job and using that.  This is more explicit, avoids race conditions, etc.
2 moves the output creation out of the create transmux function so we dont create a new output for every transmuxing.  We only need one new output per job.  The transmuxings can share.  