### PR TITLE
Update transmuxing parameters

### DIFF
--- a/event.json
+++ b/event.json
@@ -1,3 +1,3 @@
 {
-    "body": "{\"payload\":{\"outputUrl\":\"https://s3.amazonaws.com/execonline-staging-video/bitmovin/558134_27409232e193d8a2b0ff95d882486746\",\"jobId\":\"558134\"}}"
+    "body": "{\"payload\":{\"outputUrl\":\"https://s3.amazonaws.com/execonline-staging-video/bitmovin/558343_63e2aa6144f552d15b89d1d684aeeec0\",\"jobId\":\"558343\"}}"
 }

--- a/src/BitmovinTransmuxingLambda/index.js
+++ b/src/BitmovinTransmuxingLambda/index.js
@@ -1,8 +1,8 @@
 const videoStreamIndex = (quality) => {
   switch (quality) {
-    case 'low.mp4': return 4;
-    case 'medium.mp4': return 2;
-    case 'high.mp4': return 0;
+    case 'mobile.mp4': return 5;
+    case 'medium.mp4': return 0;
+    case 'high.mp4': return 1;
   }
 } 
 
@@ -13,7 +13,7 @@ const getRepresentationId = (quality, videoStreamConfigs) => {
 }
 
 const createOutput = (bitcodin, outputPath, jobId) => {
-  let lowOutputParams = {
+  let outputParams = {
     "type": "s3",
     "name": process.env.ENVIRONMENT + "/" + outputPath,
     "region": "us-east-1",
@@ -24,7 +24,7 @@ const createOutput = (bitcodin, outputPath, jobId) => {
     "makePublic": true
   };
 
-  bitcodin.output.s3.create(lowOutputParams).then(
+  bitcodin.output.s3.create(outputParams).then(
     (createOutputResponse) => {
       bitcodin.output.list(0, 'finished').then(
         (outputResponse) => {
@@ -88,7 +88,7 @@ const createTransmux = quality => (bitcodin, outputPath, jobId, outputId) => {
   );    
 }
 
-const createLowTransmux = createTransmux("low");
+const createLowTransmux = createTransmux("mobile");
 
 const createMediumTransmux = createTransmux("medium");
 


### PR DESCRIPTION
We updated our encoding profile for new video encodings, so we needed to update which streams we want to transmux.  We decided to transmux the 720, smaller 1080, and 240p files as medium, high, and mobile.mp4 files respectively.  The files will act as a backup to the HLS streams.

tags: bitmovin, transmuxing, stream selection